### PR TITLE
io discard instead of multiple `if debug {}`

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,14 +1,12 @@
 package fscache
 
 import (
-	"os"
+	"io"
 	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
 )
-
-var debug bool
 
 type (
 	// MemdisData object
@@ -41,7 +39,7 @@ type (
 	// Operations lists all available operations on the fs-cache
 	Operations interface {
 		// Debug() enables debug to get certain logs
-		Debug()
+		Debug(io.Writer)
 
 		// Memdis gives you a Redis-like feature similarly as you would with a Redis database
 		Memdis() *Memdis
@@ -53,7 +51,7 @@ type (
 // New initializes an instance of the in-memory storage cache
 func New() Operations {
 	var memdicSorage []map[string]MemdisData
-	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	logger := zerolog.New(io.Discard)
 	mu := sync.RWMutex{}
 	md := Memdis{
 		mu:      &mu,
@@ -80,8 +78,11 @@ func New() Operations {
 }
 
 // Debug() enables debug to get certain logs
-func (*Cache) Debug() {
-	debug = true
+func (c *Cache) Debug(w io.Writer) {
+	logger := zerolog.New(w).With().Timestamp().Logger()
+	c.logger = logger
+	c.MemdisInstance.logger = logger
+	c.MemgodbInstance.logger = logger
 }
 
 // KeyValue returns methods for key-value pair storage
@@ -102,15 +103,11 @@ func (ch *Cache) runner() {
 	defer ticker.Stop()
 
 	for range ticker.C {
-		if debug {
-			ch.logger.Info().Msg("cron job running...")
-		}
+		ch.logger.Info().Msg("cron job running...")
 
 		if persistMemgodbData {
 			if err := ch.MemgodbInstance.Persist(); err != nil {
-				if debug {
-					ch.logger.Info().Msgf("persist error: %v", err)
-				}
+				ch.logger.Info().Msgf("persist error: %v", err)
 			}
 		}
 
@@ -119,9 +116,7 @@ func (ch *Cache) runner() {
 				currentTime := time.Now()
 				if currentTime.Before(value.Duration) {
 					ch.Memdis().mu.Lock()
-					if debug {
-						ch.logger.Info().Msgf("data object [%v] got expired ", ch.MemdisInstance.storage[i])
-					}
+					ch.logger.Info().Msgf("data object [%v] got expired ", ch.MemdisInstance.storage[i])
 					// take the data from off the array object
 					ch.MemdisInstance.storage = append(ch.MemdisInstance.storage[:i], ch.MemdisInstance.storage[i+1:]...)
 					// decrement the array index by 1 since an object have been taken off the array

--- a/memdis_test.go
+++ b/memdis_test.go
@@ -1,6 +1,8 @@
 package fscache
 
 import (
+	"bytes"
+	"io"
 	"testing"
 	"time"
 
@@ -105,8 +107,19 @@ func TestDebug(t *testing.T) {
 		MemdisInstance: md,
 	}
 
-	ch.Debug()
-	assert.True(t, debug)
+	buf := bytes.NewBuffer(nil)
+
+	ch.Memdis().logger.Info().Msg("hello world - testing") // before enabling debug logging
+	data, err := io.ReadAll(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, string(data), "")
+
+	ch.Debug(buf)
+	ch.Memdis().logger.Info().Msg("hello world - testing") // after enabling debug logging
+
+	data, err = io.ReadAll(buf)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "hello world - testing")
 }
 
 func TestOverWrite(t *testing.T) {

--- a/memgodb.go
+++ b/memgodb.go
@@ -75,16 +75,12 @@ func (ns *Memgodb) Collection(col any) *Collection {
 
 	// run validation
 	if reflect.ValueOf(col).IsZero() && col == nil {
-		if debug {
-			ns.logger.Error().Msg("Collection cannot be empty...")
-		}
+		ns.logger.Error().Msg("Collection cannot be empty...")
 		panic("Collection cannot be empty...")
 	}
 
 	if t.Kind() != reflect.Struct && t.Kind() != reflect.String {
-		if debug {
-			ns.logger.Error().Msg("Collection must either be a [string] or an [object]")
-		}
+		ns.logger.Error().Msg("Collection must either be a [string] or an [object]")
 		panic("Collection must either be a [string] or an [object]")
 	}
 


### PR DESCRIPTION
This PR address using `io.Discard` as `io.Writer` for the logger if `Operations.Debug` isn't called, in other words, if debugging isn't enabled.
So instead of checking if the _global_ `debug` variable is true to log a message, we log without checking and if debugging mode isn't enabled, the log operation will go to `io.Discard`, which in turn will have no effect, so that we simplified the process of logging and managing the global `debug` variable, which isn't a good practice.

Another change I've made, is to accept `io.Writer` as a parameter in the `Debug` function in the `Operations` interface, so that we can provide whatever implementation of `io.Writer` we want, and get rid of the coupling with the `os.Stderr` writer, getting rid of the coupling is beneficial, as you will notice in the TestDebug func, it enables me to provide `bytes.Buffer` so that I can test easily instead of reading from the hardcoded `os.Stderr` which may contain a lots of log messages as we add more and more test functions.

I'm looking forward to hearing your feedback or suggestions regarding the proposed changes.