### PR TITLE
refactored: Insert.One() and Insert.Many() removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,7 @@ if err := fs.Memgodb().Persist(); err != nil {
 ```
 
 ### Insert()
-Insert is used to insert a new record into the storage. It has two methods which are One() and Many().
-
-- ### One
-One adds a new record into the storage with collection name
+Insert is used to insert a new record into the storage.
 ```go
 type User struct {
 	Name string `json:"name"`
@@ -71,22 +68,16 @@ type User struct {
 ```go
 fs := fscache.New()
 
+// to insert single record
 var user User
 user.Name = "jane doe"
 user.Age = 20
 
-res, err := fs.Memgodb().Collection(User{}).Insert(user).One()
-if err != nil {
+if err := fs.Memgodb().Collection(User{}).Insert(user); err != nil {
 	fmt.Println(err)
 }
 
-fmt.Println(res)
-```
-- ### Many()
-Many adds many records into the storage at once
-```go
-fs := fscache.New()
-
+// to insert multiple records
 var users = []struct {
 		Name string `json:"name"`
 		Age  int    `json:"age"`
@@ -97,20 +88,19 @@ var users = []struct {
 		Age: 20},
 }
 
-if err := fs.Memgodb().Collection("user").Insert(nil).Many(users); err != nil {
+if err := fs.Memgodb().Collection("user").Insert(users); err != nil {
 	fmt.Println(err)
 }
 ```
-- ### FromJsonFile()
-FromJsonFile is a method available in Insert(). It adds record(s) into the storage from a JSON file
+### InsertFromJsonFile()
+InsertFromJsonFile adds records into the storage from a JSON file.
 ```go
 fs := fscache.New()
 
-if err := fs.Memgodb().Collection("user").Insert(nil).FromJsonFile("path to JSON file"); err != nil {
+if err := fs.Memgodb().Collection("user").InsertFromJsonFile("path to JSON file"); err != nil {
 	fmt.Println(err)
 }
 ```
-
 ### Filter()
 Filter is used to filter records from the storage. It has two methods which are First() and All().
 

--- a/example/README.md
+++ b/example/README.md
@@ -181,10 +181,7 @@ if err := fs.Memgodb().Persist(); err != nil {
 ```
 
 ### Insert()
-Insert is used to insert a new record into the storage. It has two methods which are One() and Many().
-
-- ### One
-One adds a new record into the storage with collection name
+Insert is used to insert a new record into the storage.
 ```go
 type User struct {
 	Name string `json:"name"`
@@ -194,22 +191,16 @@ type User struct {
 ```go
 fs := fscache.New()
 
+// to insert single record
 var user User
-user.Name = "jane doe" 
+user.Name = "jane doe"
 user.Age = 20
 
-res, err := fs.Memgodb().Collection(User{}).Insert(user).One()
-if err != nil {
+if err := fs.Memgodb().Collection(User{}).Insert(user); err != nil {
 	fmt.Println(err)
 }
 
-fmt.Println(res)
-```
-- ### Many()
-Many adds many records into the storage at once
-```go
-fs := fscache.New()
-
+// to insert multiple records
 var users = []struct {
 		Name string `json:"name"`
 		Age  int    `json:"age"`
@@ -220,16 +211,16 @@ var users = []struct {
 		Age: 20},
 }
 
-if err := fs.Memgodb().Collection("user").Insert(nil).Many(users); err != nil {
+if err := fs.Memgodb().Collection("user").Insert(users); err != nil {
 	fmt.Println(err)
 }
 ```
-- ### FromJsonFile()
-FromJsonFile is a method available in Insert(). It adds record(s) into the storage from a json file
+### InsertFromJsonFile()
+InsertFromJsonFile adds records into the storage from a JSON file.
 ```go
 fs := fscache.New()
 
-if err := fs.Memgodb().Collection("user").Insert(nil).FromJsonFile("path to JSON file"); err != nil {
+if err := fs.Memgodb().Collection("user").InsertFromJsonFile("path to JSON file"); err != nil {
 	fmt.Println(err)
 }
 ```

--- a/memgodb_test.go
+++ b/memgodb_test.go
@@ -39,35 +39,26 @@ func Test_Collection(t *testing.T) {
 
 func Test_Insert_One(t *testing.T) {
 	fs := New()
-	// ch := Cache{
-	// 	MemgodbInstance: Memgodb{
-	// 		mu: &sync.RWMutex{},
-	// 	},
-	// }
 
+	// insert single records
 	var counter int
 	name := fmt.Sprintf("testCase_%v", counter+1)
 	for _, v := range MemgodbTestCases {
 		t.Run(name, func(t *testing.T) {
-			res, err := fs.Memgodb().Collection("user").Insert(v).One()
+			err := fs.Memgodb().Collection("user").Insert(v)
 			require.NoError(t, err)
-			assert.NotNil(t, v, res)
 		})
 
 		counter++
 	}
-}
 
-func Test_Insert_Many(t *testing.T) {
-	ch := Cache{}
-
-	res, err := ch.Memgodb().Collection("user").Insert(nil).Many(MemgodbTestCases)
+	// to insert many records at once
+	err := fs.Memgodb().Collection("user").Insert(MemgodbTestCases)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
 }
 
-func Test_Insert_FromJsonFile(t *testing.T) {
-	ch := Cache{}
+func Test_InsertFromJsonFile(t *testing.T) {
+	fs := New()
 
 	testCases := map[string]struct {
 		fileName      string
@@ -83,7 +74,7 @@ func Test_Insert_FromJsonFile(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := ch.Memgodb().Collection("user").Insert(nil).FromJsonFile(testCase.fileName)
+			err := fs.Memgodb().Collection("user").InsertFromJsonFile(testCase.fileName)
 			assert.Equal(t, testCase.expectedError, err)
 		})
 	}
@@ -104,7 +95,7 @@ func Test_Insert_FromJsonFile(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := ch.Memgodb().Collection("user").Insert(nil).FromJsonFile(testCase.fileName)
+			err := fs.Memgodb().Collection("user").InsertFromJsonFile(testCase.fileName)
 			require.Error(t, err)
 			require.ErrorContains(t, err, testCase.expectedError.Error())
 		})
@@ -112,12 +103,11 @@ func Test_Insert_FromJsonFile(t *testing.T) {
 }
 
 func Test__Filter_First(t *testing.T) {
-	ch := Cache{}
+	fs := New()
 
 	// insert a new records
-	res, err := ch.Memgodb().Collection("user").Insert(nil).Many(MemgodbTestCases)
+	err := fs.Memgodb().Collection("user").Insert(MemgodbTestCases)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
 
 	testCases := map[string]struct {
 		expectedError error
@@ -130,7 +120,7 @@ func Test__Filter_First(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := ch.Memgodb().Collection("users").Filter(testCase.filter).First()
+			result, err := fs.Memgodb().Collection("users").Filter(testCase.filter).First()
 			require.NoError(t, err)
 			assert.NotNil(t, result)
 		})
@@ -152,7 +142,7 @@ func Test__Filter_First(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, err := ch.Memgodb().Collection("users").Filter(testCase.filter).First()
+			result, err := fs.Memgodb().Collection("users").Filter(testCase.filter).First()
 			require.ErrorIs(t, err, testCase.expectedError)
 			assert.Nil(t, result)
 		})
@@ -160,12 +150,11 @@ func Test__Filter_First(t *testing.T) {
 }
 
 func Test_Filter_All(t *testing.T) {
-	ch := Cache{}
+	fs := New()
 
 	// insert a new records
-	res, err := ch.Memgodb().Collection("user").Insert(nil).Many(MemgodbTestCases)
+	err := fs.Memgodb().Collection("user").Insert(MemgodbTestCases)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
 
 	testCases := map[string]struct {
 		expectedError error
@@ -179,7 +168,7 @@ func Test_Filter_All(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			results, err := ch.Memgodb().Collection("users").Filter(testCase.filter).All()
+			results, err := fs.Memgodb().Collection("users").Filter(testCase.filter).All()
 			require.NoError(t, err)
 			assert.NotNil(t, results)
 		})
@@ -197,19 +186,18 @@ func Test_Filter_All(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, err := ch.Memgodb().Collection("users").Filter(testCase.filter).All()
+			_, err := fs.Memgodb().Collection("users").Filter(testCase.filter).All()
 			require.ErrorIs(t, err, testCase.expectedError)
 		})
 	}
 }
 
 func Test_Delete_One(t *testing.T) {
-	ch := Cache{}
+	fs := New()
 
 	// insert a new record
-	res, err := ch.Memgodb().Collection("user").Insert(nil).Many(MemgodbTestCases)
+	err := fs.Memgodb().Collection("user").Insert(MemgodbTestCases)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
 
 	filters := map[string]map[string]any{
 		"not nil params": {"age": 35.0}, // filter out record of age 35
@@ -217,7 +205,7 @@ func Test_Delete_One(t *testing.T) {
 
 	for name, v := range filters {
 		t.Run(name, func(t *testing.T) {
-			err := ch.Memgodb().Collection("users").Delete(v).One()
+			err := fs.Memgodb().Collection("users").Delete(v).One()
 			require.NoError(t, err)
 		})
 	}
@@ -228,7 +216,7 @@ func Test_Delete_One(t *testing.T) {
 
 	for name, v := range filters {
 		t.Run(name, func(t *testing.T) {
-			err := ch.Memgodb().Collection("users").Delete(v).One()
+			err := fs.Memgodb().Collection("users").Delete(v).One()
 			require.Error(t, err)
 		})
 	}
@@ -238,9 +226,8 @@ func Test_Delete_All(t *testing.T) {
 	ch := Cache{}
 
 	// insert a new record
-	res, err := ch.Memgodb().Collection("user").Insert(nil).Many(MemgodbTestCases)
+	err := ch.Memgodb().Collection("user").Insert(MemgodbTestCases)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
 
 	filters := map[string]map[string]any{
 		"not nil params": {"age": 35.0}, // filter out record of age 35
@@ -266,12 +253,11 @@ func Test_Delete_All(t *testing.T) {
 }
 
 func Test_Update_One(t *testing.T) {
-	ch := Cache{}
+	fs := New()
 
 	// insert a new record
-	res, err := ch.Memgodb().Collection("user").Insert(nil).Many(MemgodbTestCases)
+	err := fs.Memgodb().Collection("user").Insert(MemgodbTestCases)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
 
 	testCases := map[string]struct {
 		expectedError error
@@ -307,7 +293,7 @@ func Test_Update_One(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := ch.Memgodb().Collection("user").Update(testCase.filter, testCase.update).One()
+			err := fs.Memgodb().Collection("user").Update(testCase.filter, testCase.update).One()
 			require.ErrorIs(t, err, testCase.expectedError)
 		})
 	}


### PR DESCRIPTION
The Insert() itself handles the insertion of a new record into the storage be it a slice or a map.